### PR TITLE
fixed create of factory and shopfloor

### DIFF
--- a/backend/src/endpoints/factory-site/factory-site.service.ts
+++ b/backend/src/endpoints/factory-site/factory-site.service.ts
@@ -48,7 +48,10 @@ export class FactorySiteService {
             };
             result[resultKey] = obj;
           } else {
-            result[resultKey] = data.properties[key];
+            result[resultKey] = {
+              type: "Property",
+              value: data.properties[key]
+            };
           }
         }
         //update the last urn with the current urn in scorpio

--- a/backend/src/endpoints/shop-floor/shop-floor.service.ts
+++ b/backend/src/endpoints/shop-floor/shop-floor.service.ts
@@ -63,7 +63,10 @@ export class ShopFloorService {
             };
             result[resultKey] = obj;
           } else {
-            result[resultKey] = data.properties[key];
+            result[resultKey] = {
+              type: "Property",
+              value: data.properties[key]
+            };
           }
         }
         //update the last urn with the current urn in scorpio


### PR DESCRIPTION
Like we changed asset create to have map for Property. Need to also change for factories and shofloor. In prod, the scorpio is new for PDT.

result[resultKey] = {
              type: "Property",
              value: data.properties[key]
            };