### PR TITLE
Login expiration to pages

### DIFF
--- a/frontend/src/app/withAuth.tsx
+++ b/frontend/src/app/withAuth.tsx
@@ -1,0 +1,45 @@
+// 
+// Copyright (c) 2024 IB Systems GmbH 
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License. 
+// 
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Cookies from 'js-cookie';
+import { NextComponentType, NextPageContext } from 'next';
+
+const withAuth = (WrappedComponent: NextComponentType<NextPageContext>) => {
+  const AuthComponent: NextComponentType<NextPageContext> = (props) => {
+    const router = useRouter();
+
+    useEffect(() => {
+      if (router.pathname !== '/login') {
+        const loginFlag = Cookies.get('login_flag');
+        if (!loginFlag || loginFlag !== 'true') {
+          router.push('/login');
+        }
+      }
+    }, [router]);
+
+    return <WrappedComponent {...props} />;
+  };
+
+  if (WrappedComponent.getInitialProps) {
+    AuthComponent.getInitialProps = WrappedComponent.getInitialProps;
+  }
+
+  return AuthComponent;
+};
+
+export default withAuth;

--- a/frontend/src/auth/auth-service.ts
+++ b/frontend/src/auth/auth-service.ts
@@ -47,8 +47,14 @@ const login = async (username: string, password: string): Promise<LoginResponse>
         const response: AxiosResponse<LoginResponse> = await axios.post(loginUrl as string, data, { headers });
         if (response.data.success) 
         {
-            // Set LogIn to true
-            Cookies.set('login_flag', "true", { expires: 86400 });
+            //Testing for 15 seconds
+            // const expires = new Date(new Date().getTime() + 15 * 1000); 
+            // Cookies.set('login_flag', "true", { expires });
+
+
+            //for 24 hours
+            const expires = new Date(new Date().getTime() + 24 * 60 * 60 * 1000); 
+            Cookies.set('login_flag', "true", { expires });
         }
         return response.data;
     } catch (error) {

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -22,13 +22,16 @@ import "primeicons/primeicons.css";
 import { Provider } from "react-redux";
 import { store } from "@/redux/store";
 import { appWithTranslation } from "next-i18next";
+import withAuth from "@/app/withAuth";
 
 // Import your custom components or layout components
-function MyApp({ Component, pageProps }:AppProps) {
+function MyApp({ Component, pageProps, router }:AppProps) {
   // Additional setup or global configurations can be added here
+
+  const AuthComponent = router.pathname === '/login' ? Component : withAuth(Component)
   return (
     <Provider store={store}>
-      <Component {...pageProps} />
+      <AuthComponent {...pageProps} />
     </Provider>
   );
 }

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -56,10 +56,11 @@ const Login: React.FC = () => {
         if (typeof window !== "undefined" && hasMounted && router.isReady) {
           const loginFlag = Cookies.get("login_flag");
   
-          if (loginFlag === 'true') {
-            router.push("/factory-site/factory-overview");
-  
-          }
+        if (!loginFlag || loginFlag !== 'true') {
+          router.push("/login");
+        } else {
+          router.push("/factory-site/factory-overview");
+        }
         }
       }
   }, [router.isReady, hasMounted]);


### PR DESCRIPTION
This PR is about :  
  - > The login flag will expire on 24 hours exactly the time time we logged in
                       -> then , when the token is expired , we will move to   " /login"  route  